### PR TITLE
Update names and concordances in Alicante locality record

### DIFF
--- a/data/101/748/211/101748211.geojson
+++ b/data/101/748/211/101748211.geojson
@@ -38,20 +38,20 @@
     "name:bul_x_preferred":[
         "\u0410\u043b\u0438\u043a\u0430\u043d\u0442\u0435"
     ],
+    "name:cat_x_historical":[
+        "Lucentum"
+    ],
     "name:cat_x_preferred":[
         "Alacant"
-    ],
-    "name:cat_x_variant":[
-        "Lucentum"
     ],
     "name:ceb_x_preferred":[
         "Alicante"
     ],
+    "name:deu_x_historical":[
+        "Lucentum"
+    ],
     "name:deu_x_preferred":[
         "Alicante"
-    ],
-    "name:deu_x_variant":[
-        "Lucentum"
     ],
     "name:ell_x_preferred":[
         "\u0391\u03bb\u03b9\u03ba\u03ac\u03bd\u03c4\u03b5"
@@ -59,8 +59,11 @@
     "name:ell_x_variant":[
         "\u039b\u03b5\u03c5\u03ba\u03ae \u0386\u03ba\u03c1\u03b1"
     ],
-    "name:eng_x_preferred":[
+    "name:eng_x_historical":[
         "Lucentum"
+    ],
+    "name:eng_x_preferred":[
+        "Alicante"
     ],
     "name:eng_x_variant":[
         "ALC"
@@ -77,11 +80,11 @@
     "name:fin_x_preferred":[
         "Alicante"
     ],
+    "name:fra_x_historical":[
+        "Lucentum"
+    ],
     "name:fra_x_preferred":[
         "Alicante"
-    ],
-    "name:fra_x_variant":[
-        "Lucentum"
     ],
     "name:gla_x_preferred":[
         "Alacant"
@@ -125,7 +128,7 @@
     "name:lad_x_preferred":[
         "Alikante"
     ],
-    "name:lat_x_preferred":[
+    "name:lat_x_historical":[
         "Lucentum"
     ],
     "name:lav_x_preferred":[
@@ -137,11 +140,11 @@
     "name:mar_x_preferred":[
         "\u0906\u0932\u093f\u0915\u093e\u0902\u0924\u0947"
     ],
+    "name:nld_x_historical":[
+        "Lucentum"
+    ],
     "name:nld_x_preferred":[
         "Alicante"
-    ],
-    "name:nld_x_variant":[
-        "Lucentum"
     ],
     "name:nor_x_preferred":[
         "Alicante"
@@ -170,12 +173,14 @@
     "name:scn_x_preferred":[
         "Alicanti"
     ],
+    "name:spa_x_historical":[
+        "Lucentum"
+    ],
     "name:spa_x_preferred":[
         "Alicante"
     ],
     "name:spa_x_variant":[
-        "Alacant",
-        "Lucentum"
+        "Alacant"
     ],
     "name:srp_x_preferred":[
         "\u0410\u043b\u0438\u043a\u0430\u043d\u0442\u0435"
@@ -324,8 +329,8 @@
         "gn:id":2521978,
         "gp:id":752101,
         "qs_pg:id":797454,
-        "wd:id":"Q3555926",
-        "wk:page":"Lucentum"
+        "wd:id":"Q11959",
+        "wk:page":"Alicante"
     },
     "wof:country":"ES",
     "wof:geomhash":"49b390f7069de27f8d91b2ae159d44c5",
@@ -340,10 +345,13 @@
         }
     ],
     "wof:id":101748211,
-    "wof:lang":[
+    "wof:lang_x_official":[
         "spa"
     ],
-    "wof:lastmodified":1566589113,
+    "wof:lang_x_spoken":[
+        "spa"
+    ],
+    "wof:lastmodified":1574291480,
     "wof:name":"Alicante",
     "wof:parent_id":404329281,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1743

This PR Updates name translations, language codes, and concordances to point to "Alicante", rather than the historical "Lucentum". When historical names were present, they were moved into a `*_x_historical` namespace.

No PIP work required, can merge once approved.
