### PR TITLE
Update properties of megacities

### DIFF
--- a/data/101/748/241/101748241.geojson
+++ b/data/101/748/241/101748241.geojson
@@ -609,6 +609,7 @@
         "fct:id":"0844bca4-8f76-11e1-848f-cfd5bf3ef515",
         "gn:id":2509954,
         "gp:id":776688,
+        "ne:id":1159150791,
         "nyt:id":"N78842535258146531031",
         "qs_pg:id":800840,
         "wd:id":"Q8818",
@@ -633,7 +634,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1587429002,
+    "wof:lastmodified":1608688177,
     "wof:megacity":1,
     "wof:name":"Valencia",
     "wof:parent_id":404345361,

--- a/data/101/748/283/101748283.geojson
+++ b/data/101/748/283/101748283.geojson
@@ -19,7 +19,7 @@
     "mps:longitude":-3.678212,
     "mz:hierarchy_label":1,
     "mz:is_current":1,
-    "mz:min_zoom":4.0,
+    "mz:min_zoom":3.0,
     "name:abk_x_preferred":[
         "\u041ca\u0434\u0440\u0438\u0434"
     ],
@@ -829,6 +829,7 @@
         "gn:id":3117735,
         "gp:id":766273,
         "loc:id":"n78089046",
+        "ne:id":1159151503,
         "nyt:id":"51083708004460018461",
         "qs_pg:id":799363,
         "wd:id":"Q2807",
@@ -853,7 +854,8 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1607390881,
+    "wof:lastmodified":1608688189,
+    "wof:megacity":1,
     "wof:name":"Madrid",
     "wof:parent_id":85682783,
     "wof:placetype":"locality",

--- a/data/101/748/323/101748323.geojson
+++ b/data/101/748/323/101748323.geojson
@@ -804,6 +804,7 @@
         "gn:id":3128760,
         "gp:id":753692,
         "loc:id":"n79021052",
+        "ne:id":1159151261,
         "nyt:id":"N24021898531366062201",
         "qs_pg:id":797713,
         "wd:id":"Q1492",
@@ -828,7 +829,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1587429000,
+    "wof:lastmodified":1608688183,
     "wof:megacity":1,
     "wof:name":"Barcelona",
     "wof:parent_id":85682663,


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1547

- Updates megacity records with new:
  - concordances
  - names (if not already present)
  - label centroids
  - megacity flags
- Updates geometries of any megacity record with a `Point` geometry
- Updates parent geometries when necessary